### PR TITLE
fix simphony-common version to 0.1.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,13 @@ Repository
 
 Simphony-openfoam is hosted on github: https://github.com/simphony/simphony-openfoam
 
+Requirements
+------------
+
+- `simphony-common`_ == 0.1.3
+
+.. _simphony-common: https://github.com/simphony/simphony-common
+
 Installation
 ------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git://github.com/simphony/simphony-common.git#egg=simphony
+-e git+git://github.com/simphony/simphony-common.git@0.1.3#egg=simphony

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     description='Implementation of OpenFoam wrappers',
     long_description=README_TEXT,
     packages=find_packages(),
-    install_requires=['simphony'],
+    install_requires=['simphony == 0.1.3'],
     entry_points={
         'simphony.engine': ['openfoam = foam_controlwrapper']}
 )


### PR DESCRIPTION
This PR sets the `simphony-common` version to 0.1.3 so that the unit tests can be run (as files used in testing can not be read with `simphony` > 0.1.3).

