### PR TITLE
pyFoam installation forced to 0.6.4

### DIFF
--- a/install_external.sh
+++ b/install_external.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 # install pyFoam
-mkdir -p src/simphony-openfoam/pyfoam
-wget https://openfoamwiki.net/images/3/3b/PyFoam-0.6.4.tar.gz -O src/simphony-openfoam/pyfoam/pyfoam.tgz --no-check-certificate
-tar -xzf src/simphony-openfoam/pyfoam/pyfoam.tgz -C src/simphony-openfoam/pyfoam
-pip install --upgrade src/simphony-openfoam/pyfoam/PyFoam-0.6.4
-rm -Rf src/simphony-openfoam/pyfoam
+mkdir -p pyfoam_install
+wget https://openfoamwiki.net/images/3/3b/PyFoam-0.6.4.tar.gz -O pyfoam_install/pyfoam.tgz --no-check-certificate
+tar -xzf pyfoam_install/pyfoam.tgz -C pyfoam_install
+pip install --upgrade pyfoam_install/PyFoam-0.6.4
+rm -fr pyfoam_install
 source /opt/openfoam222/etc/bashrc
 python check_PyFoam.py

--- a/install_external.sh
+++ b/install_external.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 set -e
 # install pyFoam
-# fetch pyFoam
-svn co https://svn.code.sf.net/p/openfoam-extend/svn/trunk/Breeder/other/scripting/PyFoam/
-# move to installation directory
-cd PyFoam
-python setup.py install
-cd ..
+mkdir -p src/simphony-openfoam/pyfoam
+wget https://openfoamwiki.net/images/3/3b/PyFoam-0.6.4.tar.gz -O src/simphony-openfoam/pyfoam/pyfoam.tgz --no-check-certificate
+tar -xzf src/simphony-openfoam/pyfoam/pyfoam.tgz -C src/simphony-openfoam/pyfoam
+pip install --upgrade src/simphony-openfoam/pyfoam/PyFoam-0.6.4
+rm -Rf src/simphony-openfoam/pyfoam
 source /opt/openfoam222/etc/bashrc
 python check_PyFoam.py

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setup(
     description='Implementation of OpenFoam wrappers',
     long_description=README_TEXT,
     packages=find_packages(),
-    install_requires=['simphony == 0.1.3'],
+    install_requires=['simphony == 0.1.3',
+                      'PyFoam == 0.6.4'],
     entry_points={'simphony.engine':
                   ['openfoam_file_io = foam_controlwrapper',
                    'openfoam_internal = foam_internalwrapper']},


### PR DESCRIPTION
PyFoam installation requires now 0.6.4 version