### PR TITLE
Stabilizes the installation of openfoam from apt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ matrix:
   allow_failures:
     - env: SIMPHONY_VERSION=master
 before_install:
-  - sudo sh -c "echo deb http://www.openfoam.org/download/ubuntu precise main > /etc/apt/sources.list.d/openfoam.list"
+   
+  - sudo add-apt-repository http://dl.openfoam.org/ubuntu
+  - sudo sh -c "wget -O - http://dl.openfoam.org/gpg.key | apt-key add -"
   - sudo apt-get update -qq
   - sudo apt-get install -y --force-yes openfoam230
   - sudo apt-get install libhdf5-serial-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ matrix:
   allow_failures:
     - env: SIMPHONY_VERSION=master
 before_install:
-   
-  - sudo add-apt-repository http://dl.openfoam.org/ubuntu
-  - sudo sh -c "wget -O - http://dl.openfoam.org/gpg.key | apt-key add -"
+  - echo "deb http://dl.openfoam.org/ubuntu precise main" > /etc/apt/sources.list.d/openfoam.list
   - sudo apt-get update -qq
   - sudo apt-get install -y --force-yes openfoam230
   - sudo apt-get install libhdf5-serial-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
   allow_failures:
     - env: SIMPHONY_VERSION=master
 before_install:
-  - echo "deb http://dl.openfoam.org/ubuntu precise main" > /etc/apt/sources.list.d/openfoam.list
+  - sudo sh -c 'echo "deb http://dl.openfoam.org/ubuntu precise main" > /etc/apt/sources.list.d/openfoam.list'
   - sudo apt-get update -qq
   - sudo apt-get install -y --force-yes openfoam230
   - sudo apt-get install libhdf5-serial-dev


### PR DESCRIPTION
Solves the instability of downloading openfoam by using the recommended procedure to add the apt repository.

@khiltunen This should solve your issue. I'll merge when green. Please bring in master to your branch when merged.