### PR TITLE
Add edm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ openfoam-interface/lnInclude
 *.dep
 
 */version.py
+.devenv

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,8 @@ openfoam-interface/lnInclude
 
 */version.py
 .devenv
+linux64GccDPOpt
+lnInclude
+incompressibleTurbulenceModel
+endist
+

--- a/README.rst
+++ b/README.rst
@@ -63,3 +63,26 @@ To run the cleaner run::
 
     python setup.py clean
 
+
+EDM egg build and uploading
+---------------------------
+
+The repository supports building of EDM packages. The command::
+    
+    python edmsetup.py egg
+
+Creates the egg, and the command::
+
+    python edmsetup.py upload_egg
+
+uploads it to EDM repository. An important difference with respect to other EDM-enhanced repositories
+is that due to the current layout of the repository, we are building **two** eggs. The consequence is that
+there are **two** packageinfo.py with different package names, release tags and build numbers. 
+Check under ``openfoam-interface/wrapper/`` for the secondary packageinfo.py.
+
+The automatic Jenkins based builder creates new eggs for branches named ``release-<version>-<build>``.
+To do a new build (or release), you should modify the relevant packageinfo.py, merge the PR to master, then 
+create the above branch to trigger the build and upload of the new eggs.
+
+For additional information about the EDM build system, check the ``simphonyproject/buildrecipes-common`` 
+repository.

--- a/edmenv.sh
+++ b/edmenv.sh
@@ -1,0 +1,7 @@
+export PATH=/usr/lib64/openmpi/bin/:$PATH
+export LD_LIBRARY_PATH=/usr/lib64/openmpi/lib/:$LD_LIBRARY_PATH
+# openfoam bashrc script has the annoying property of removing our current path, 
+# leaving us with nothing of our custom installations
+oldpath=$PATH
+. /opt/OpenFOAM-2.3.0/etc/bashrc
+export PATH=$oldpath:$PATH

--- a/edmsetup.py
+++ b/edmsetup.py
@@ -1,0 +1,69 @@
+# Basic template for edm setup.
+# Copy this file to retrieve the buildcommons repository
+# This template can be used as is on trivial "setup.py only"
+# packages.
+# It requires the additional files:
+# - a packageinfo.py containing the relevant data.
+# - an endist.dat file, containing the relevant data.
+import sys
+import click
+import os
+import subprocess
+
+from packageinfo import BUILD, VERSION, NAME
+
+# The version of the buildcommon to checkout.
+BUILDCOMMONS_VERSION="v0.1"
+
+
+def bootstrap_devenv():
+    try:
+        os.makedirs(".devenv")
+    except OSError:
+        pass
+
+    if not os.path.exists(".devenv/buildrecipes-common"):
+        subprocess.check_call([
+            "git", "clone", "-b", BUILDCOMMONS_VERSION,
+            "http://github.com/simphony/buildrecipes-common.git",
+            ".devenv/buildrecipes-common"
+            ])
+    sys.path.insert(0, ".devenv/buildrecipes-common")
+
+
+bootstrap_devenv()
+import buildcommons as common  # noqa
+
+
+workspace = common.workspace()
+common.edmenv_setup()
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.command()
+def egg():
+    common.local_repo_to_edm_egg(".", name=NAME, version=VERSION, build=BUILD)
+
+
+@cli.command()
+def upload_egg():
+    egg_path = "endist/{NAME}-{VERSION}-{BUILD}.egg".format(
+        NAME=NAME,
+        VERSION=VERSION,
+        BUILD=BUILD)
+    click.echo("Uploading {} to EDM repo".format(egg_path))
+    common.upload_egg(egg_path)
+    click.echo("Done")
+
+
+@cli.command()
+def clean():
+    click.echo("Cleaning")
+    common.clean(["endist", ".devenv"])
+
+
+cli()

--- a/edmsetup.py
+++ b/edmsetup.py
@@ -1,10 +1,3 @@
-# Basic template for edm setup.
-# Copy this file to retrieve the buildcommons repository
-# This template can be used as is on trivial "setup.py only"
-# packages.
-# It requires the additional files:
-# - a packageinfo.py containing the relevant data.
-# - an endist.dat file, containing the relevant data.
 import sys
 import click
 import os

--- a/edmsetup.py
+++ b/edmsetup.py
@@ -66,7 +66,10 @@ def upload_egg():
     common.upload_egg(egg_path)
 
     with common.cd("openfoam-interface/internal-interface/wrapper"):
-        common.run("python edmsetup.py upload_egg")
+        try:
+            common.run("python edmsetup.py upload_egg")
+        except subprocess.CalledProcessError as e:
+            print("Error during egg upload of submodule. {}. Continuing".format(e.message))
 
     click.echo("Done")
 

--- a/edmsetup.py
+++ b/edmsetup.py
@@ -69,7 +69,7 @@ def upload_egg():
         try:
             common.run("python edmsetup.py upload_egg")
         except subprocess.CalledProcessError as e:
-            print("Error during egg upload of submodule. {}. Continuing".format(e.message))
+            print("Error during egg upload of submodule: {}. Continuing.".format(e))
 
     click.echo("Done")
 

--- a/endist.dat
+++ b/endist.dat
@@ -1,0 +1,5 @@
+packages = [
+  # A list of strings in the format 
+  # "dependency_name dependency_version_at_patchlevel_detail"
+    "simphony 0.8.0.dev0"
+]

--- a/endist.dat
+++ b/endist.dat
@@ -3,4 +3,5 @@ packages = [
   # "dependency_name dependency_version_at_patchlevel_detail"
     "simphony 0.8.0.dev0",
     "FoamInterface 0.2.4.dev0",
+    "PyFoam 0.6.4",
 ]

--- a/endist.dat
+++ b/endist.dat
@@ -1,5 +1,6 @@
 packages = [
   # A list of strings in the format 
   # "dependency_name dependency_version_at_patchlevel_detail"
-    "simphony 0.8.0.dev0"
+    "simphony 0.8.0.dev0",
+    "FoamInterface 0.2.4.dev0",
 ]

--- a/openfoam-interface/internal-interface/wrapper/edmsetup.py
+++ b/openfoam-interface/internal-interface/wrapper/edmsetup.py
@@ -1,10 +1,3 @@
-# Basic template for edm setup.
-# Copy this file to retrieve the buildcommons repository
-# This template can be used as is on trivial "setup.py only"
-# packages.
-# It requires the additional files:
-# - a packageinfo.py containing the relevant data.
-# - an endist.dat file, containing the relevant data.
 import sys
 import click
 import os

--- a/openfoam-interface/internal-interface/wrapper/endist.dat
+++ b/openfoam-interface/internal-interface/wrapper/endist.dat
@@ -1,0 +1,10 @@
+
+packages = [
+  # A list of strings in the format
+  # "dependency_name dependency_version_at_patchlevel_detail"
+]
+add_files=[
+    ("/home/sbo/OpenFOAM/sbo-2.3.0/platforms/linux64GccDPOpt/bin", ".*", "EGG-INFO/usr/bin/"),
+    ("/home/sbo/OpenFOAM/sbo-2.3.0/platforms/linux64GccDPOpt/lib", ".*", "EGG-INFO/usr/lib/"),
+    (".", "post_egginst.py", "EGG-INFO/"),
+]

--- a/openfoam-interface/internal-interface/wrapper/packageinfo.py
+++ b/openfoam-interface/internal-interface/wrapper/packageinfo.py
@@ -6,4 +6,4 @@ VERSION = "0.2.4.dev0"
 
 # EDM build of the package. Increment in case of rebuilding an incorrectly
 # built package that has already been sent to the package server.
-BUILD = "1"
+BUILD = "2"

--- a/openfoam-interface/internal-interface/wrapper/packageinfo.py
+++ b/openfoam-interface/internal-interface/wrapper/packageinfo.py
@@ -1,0 +1,9 @@
+# The package name in the setup.py
+NAME = "FoamInterface"
+
+# Semantic version.
+VERSION = "0.2.4.dev0"
+
+# EDM build of the package. Increment in case of rebuilding an incorrectly
+# built package that has already been sent to the package server.
+BUILD = "1"

--- a/openfoam-interface/internal-interface/wrapper/post_egginst.py
+++ b/openfoam-interface/internal-interface/wrapper/post_egginst.py
@@ -1,0 +1,40 @@
+import os
+import shutil
+import sys
+
+print("Post installation")
+
+lib_dest = os.path.expandvars("$HOME/OpenFOAM/$USER-2.3.0/platforms/linux64GccDPOpt/lib")
+bin_dest = os.path.expandvars("$HOME/OpenFOAM/$USER-2.3.0/platforms/linux64GccDPOpt/bin")
+
+try:
+    os.makedirs(lib_dest)
+except OSError:
+    # Already existent
+    pass
+
+try:
+    os.makedirs(bin_dest)
+except OSError:
+    # Already existent
+    pass
+
+print("Installing extension files in home directory")
+
+for f in ["driftFluxSimphonyFoam", "pimpleSimphonyFoam", "simpleSimphonyFoam"]:
+    shutil.copy(os.path.join(sys.exec_prefix, "bin", f), bin_dest)
+
+for f in [
+    "libdriftFluxRelativeVelocityModelsII.so",
+    "libdriftFluxRelativeVelocityModels.so",
+    "libdriftFluxTransportModels.so",
+    "libfoaminterface.so",
+    "libincompressibleRASModelsSimphony.so",
+    "libincompressibleTransportModelSimphony.so",
+    "libincompressibleTurbulenceModelSimphony.so",
+    "libshearStressPowerLawSlipVelocityIO.so",
+    "libshearStressPowerLawSlipVelocity.so"]:
+
+    shutil.copy(os.path.join(sys.exec_prefix, "lib", f), lib_dest)
+
+print("Done")

--- a/openfoam-interface/internal-interface/wrapper/setup.py
+++ b/openfoam-interface/internal-interface/wrapper/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import os
 
 openfoam_src_dir = os.environ['FOAM_SRC']

--- a/packageinfo.py
+++ b/packageinfo.py
@@ -1,0 +1,9 @@
+# The package name in the setup.py
+NAME = "foam_wrappers"
+
+# Semantic version.
+VERSION = "0.4.0.dev0"
+
+# EDM build of the package. Increment in case of rebuilding an incorrectly
+# built package that has already been sent to the package server.
+BUILD = "1"

--- a/packageinfo.py
+++ b/packageinfo.py
@@ -6,4 +6,4 @@ VERSION = "0.4.0.dev0"
 
 # EDM build of the package. Increment in case of rebuilding an incorrectly
 # built package that has already been sent to the package server.
-BUILD = "1"
+BUILD = "2"

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@ import os
 import sys
 
 from setuptools import setup, find_packages, Command
-from setuptools.command.install import install
+from setuptools.command.bdist_egg import bdist_egg
+from packageinfo import NAME, VERSION
+
 
 with open('README.rst', 'r') as readme:
     README_TEXT = readme.read()
 
-VERSION = '0.4.0.dev0'
 
 
 class CleanCommand(Command):
@@ -26,14 +27,14 @@ class CleanCommand(Command):
         os.system('./Allwclean')
 
 
-class InstallCommand(install):
-    """Customized setuptools install command - prints a friendly greeting."""
+class BdistEggCommand(bdist_egg):
+    """Customized setuptools bdist_egg command - prints a friendly greeting."""
     def run(self):
         if '--user' in sys.argv:
             os.system("./install_foam_interface.sh --user")
         else:
             os.system("./install_foam_interface.sh")
-        install.run(self)
+        bdist_egg.run(self)
 
 
 def write_version_py(filename=None):
@@ -57,17 +58,17 @@ write_version_py(os.path.join(os.path.dirname(__file__),
                               'foam_internalwrapper', 'version.py'))
 
 setup(
-    name='foam_wrappers',
+    name=NAME,
     version=VERSION,
     author='SimPhoNy FP7 European Project',
     description='Implementation of OpenFoam wrappers',
     long_description=README_TEXT,
     packages=find_packages(),
-    install_requires=['simphony[H5IO, CUBAGen]>=0.5'],
+    install_requires=['simphony>=0.5'],
     entry_points={'simphony.engine':
                   ['openfoam_file_io = foam_controlwrapper',
                    'openfoam_internal = foam_internalwrapper']},
     cmdclass={
         'clean': CleanCommand,
-        'install': InstallCommand}
+        'bdist_egg': BdistEggCommand}
 )


### PR DESCRIPTION
Included build support for EDM packaging. Produces and uploads two eggs, one for the binary interface, the other for the python interface.

